### PR TITLE
[#102] Support query prefix option

### DIFF
--- a/lib/flop.ex
+++ b/lib/flop.ex
@@ -669,6 +669,9 @@ defmodule Flop do
   end
 
   def meta(q, flop, opts) do
+    repo = option_or_default(opts, :repo) || raise no_repo_error("meta")
+    opts = Keyword.put(opts, :repo, repo)
+
     total_count = count(q, flop, opts)
     page_size = flop.page_size || flop.limit
     total_pages = get_total_pages(total_count, page_size)

--- a/lib/flop.ex
+++ b/lib/flop.ex
@@ -319,8 +319,8 @@ defmodule Flop do
           | {:max_limit, pos_integer}
           | {:ordering, boolean}
           | {:pagination_types, [pagination_type()]}
-          | {:repo, module}
           | {:prefix, binary}
+          | {:repo, module}
 
   @typedoc """
   Represents the supported order direction values.
@@ -449,7 +449,7 @@ defmodule Flop do
   @doc since: "0.6.0"
   @spec all(Queryable.t(), Flop.t(), [option()]) :: [any]
   def all(q, flop, opts \\ []) do
-    apply_on_repo(:all, [query(q, flop)], opts)
+    apply_on_repo(:all, "all", [query(q, flop)], opts)
   end
 
   @doc """
@@ -1251,9 +1251,8 @@ defmodule Flop do
     {[field | order_by || []], [new_direction | order_directions || []]}
   end
 
-  defp apply_on_repo(repo_fn, flop_fn \\ nil, args, opts) do
-    repo =
-      option_or_default(opts, :repo) || raise no_repo_error(flop_fn || repo_fn)
+  defp apply_on_repo(repo_fn, flop_fn, args, opts) do
+    repo = option_or_default(opts, :repo) || raise no_repo_error(flop_fn)
 
     opts =
       if prefix = option_or_default(opts, :prefix) do

--- a/priv/repo/migrations/20210523123456_create_pets_in_second_schema.exs
+++ b/priv/repo/migrations/20210523123456_create_pets_in_second_schema.exs
@@ -1,0 +1,13 @@
+defmodule Flop.Repo.Migrations.CreatePetsInSecondSchema do
+  use Ecto.Migration
+
+  def change do
+    execute("CREATE SCHEMA other_schema;", "DROP SCHEMA other_schema;")
+
+    create table(:pets, prefix: "other_schema") do
+      add(:name, :string)
+      add(:age, :integer)
+      add(:species, :string)
+    end
+  end
+end

--- a/test/flop_test.exs
+++ b/test/flop_test.exs
@@ -629,6 +629,13 @@ defmodule FlopTest do
 
       assert Enum.map(Flop.all(Pet, flop), & &1.name) == [name_1, name_2]
     end
+
+    test "can apply a query prefix" do
+      insert(:pet, %{}, prefix: "other_schema")
+
+      assert Flop.all(Pet, %Flop{}) == []
+      refute Flop.all(Pet, %Flop{}, prefix: "other_schema") == []
+    end
   end
 
   describe "count/3" do
@@ -644,6 +651,13 @@ defmodule FlopTest do
       }
 
       assert Flop.count(Pet, flop) == 6
+    end
+
+    test "can apply a query prefix" do
+      insert(:pet, %{}, prefix: "other_schema")
+
+      assert Flop.count(Pet, %Flop{}) == 0
+      assert Flop.count(Pet, %Flop{}, prefix: "other_schema") == 1
     end
   end
 
@@ -789,6 +803,13 @@ defmodule FlopTest do
 
       assert %Meta{has_next_page?: false, has_previous_page?: true} =
                Flop.meta(Pet, %Flop{page_size: 3, page: 2})
+    end
+
+    test "can apply a query prefix" do
+      insert(:pet, %{}, prefix: "other_schema")
+
+      assert Flop.meta(Pet, %Flop{}).total_count == 0
+      assert Flop.meta(Pet, %Flop{}, prefix: "other_schema").total_count == 1
     end
   end
 


### PR DESCRIPTION
Hello again 👋 

this is a first attempt at adding support for Ecto's `:prefix` option.

## Some notes

* I chose to pass it to the `Repo.all`/`Repo.aggregate` function calls instead of using [`put_query_prefix/2`](https://hexdocs.pm/ecto/Ecto.Query.html#put_query_prefix/2) - the outcome is the same, and I didn't see a reason to store it in the query. Also, I didn't want to mess with `Flop.t` to get it into the `Flop.query/2` function.
* ~~Didn't see why the `:repo` option was fetched in `Flop.meta/3`, so I changed it to just pass on the `opts` list instead.~~

## TODOs

- [x] Tests... `test/flop_test.exs` is quite the opus magnum :-) Wanted to wait for your feedback on the code first, and perhaps some guidance on how to test this.

Hope this is somewhat useful already!

Will eventually fix #102.

best,
malte