### PR TITLE
Fix callback type mismatch in Flop.Schema

### DIFF
--- a/lib/flop/schema.ex
+++ b/lib/flop/schema.ex
@@ -375,10 +375,12 @@ defprotocol Flop.Schema do
       %{order_by: [:name], order_directions: [:asc]}
   """
   @doc since: "0.7.0"
-  @spec default_order(any) :: %{
-          order_by: [atom] | nil,
-          order_directions: [Flop.order_direction()] | nil
-        }
+  @spec default_order(any) ::
+          %{
+            order_by: [atom] | nil,
+            order_directions: [Flop.order_direction()] | nil
+          }
+          | nil
   def default_order(data)
 
   @doc """


### PR DESCRIPTION
Hello again :wave: 

When deriving a schema without specifying a `default_order` map,
dialyzer complains that the implementation of `default_order/1` does not
match the signature of the specified callback.

```
my_schema.ex:-1:callback_type_mismatch
Type mismatch for @callback default_order/1 in Flop.Schema behaviour.

Expected type:
%{
  :order_by => nil | [atom()],
  :order_directions =>
    nil
    | [
        :asc
        | :asc_nulls_first
        | :asc_nulls_last
        | :desc
        | :desc_nulls_first
        | :desc_nulls_last
      ]
}

Actual type:
nil
```