### PR TITLE
Accept binary fields (fixes count query)

### DIFF
--- a/lib/flop/builder.ex
+++ b/lib/flop/builder.ex
@@ -213,7 +213,7 @@ defmodule Flop.Builder do
 
   defp get_field_type(nil, field), do: {:normal, field}
 
-  defp get_field_type(struct, field) when is_atom(field) do
+  defp get_field_type(struct, field) when is_atom(field) or is_binary(field) do
     Flop.Schema.field_type(struct, field)
   end
 end

--- a/lib/flop/builder.ex
+++ b/lib/flop/builder.ex
@@ -213,7 +213,11 @@ defmodule Flop.Builder do
 
   defp get_field_type(nil, field), do: {:normal, field}
 
-  defp get_field_type(struct, field) when is_atom(field) or is_binary(field) do
+  defp get_field_type(struct, field) when is_binary(field) do
+    get_field_type(struct, String.to_existing_atom(field))
+  end
+
+  defp get_field_type(struct, field) when is_atom(field) do
     Flop.Schema.field_type(struct, field)
   end
 end


### PR DESCRIPTION
**Description**

Flop.count apparently works differently from Flop.query and does not accept filters with string fields.
This looks like because Flop.Builder.get_field_type doesn't. Changing this fixes it for me.

**Checklist**

- [ ] I added tests that cover my proposed changes.
- [ ] I updated the documentation related to my changes (if applicable).
