### PR TITLE
fix: don't let backend config override schema config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Changed
+
+- Added a `backend` field to the `Flop.Meta` struct.
+
+### Fixed
+
+- Fixed an issue where the schema options were overridden by the backend module
+  options.
+
 ## [0.17.0] - 2022-08-26
 
 ### Added


### PR DESCRIPTION
resolves #236 
relates to #237 