### PR TITLE
Filters using `i/like_and` `i/like_or` now expect a list of strings

### DIFF
--- a/lib/flop/filter.ex
+++ b/lib/flop/filter.ex
@@ -50,10 +50,14 @@ defmodule Flop.Filter do
   | `:not_contains` | `"pear"`            | `WHERE 'pear' = NOT IN(column)`                         |
   | `:like`         | `"cyth"`            | `WHERE column LIKE '%cyth%'`                            |
   | `:like_and`     | `["Rubi", "Rosa"]`  | `WHERE column LIKE '%Rubi%' AND column LIKE '%Rosa%'`   |
+  | `:like_and`     | `"Rubi Rosa"`       | `WHERE column LIKE '%Rubi%' AND column LIKE '%Rosa%'`   |
   | `:like_or`      | `["Rubi", "Rosa"]`  | `WHERE column LIKE '%Rubi%' OR column LIKE '%Rosa%'`    |
+  | `:like_or`      | `"Rubi Rosa"`       | `WHERE column LIKE '%Rubi%' OR column LIKE '%Rosa%'`    |
   | `:ilike`        | `"cyth"`            | `WHERE column ILIKE '%cyth%'`                           |
   | `:ilike_and`    | `["Rubi", "Rosa"]`  | `WHERE column ILIKE '%Rubi%' AND column ILIKE '%Rosa%'` |
+  | `:ilike_and`    | `"Rubi Rosa"`       | `WHERE column ILIKE '%Rubi%' AND column ILIKE '%Rosa%'` |
   | `:ilike_or`     | `["Rubi", "Rosa"]`  | `WHERE column ILIKE '%Rubi%' OR column ILIKE '%Rosa%'`  |
+  | `:ilike_or`     | `"Rubi Rosa"`       | `WHERE column ILIKE '%Rubi%' OR column ILIKE '%Rosa%'`  |
   """
   @type op ::
           :==

--- a/lib/flop/filter.ex
+++ b/lib/flop/filter.ex
@@ -49,11 +49,11 @@ defmodule Flop.Filter do
   | `:contains`     | `"pear"`            | `WHERE 'pear' = ANY(column)`                            |
   | `:not_contains` | `"pear"`            | `WHERE 'pear' = NOT IN(column)`                         |
   | `:like`         | `"cyth"`            | `WHERE column LIKE '%cyth%'`                            |
-  | `:like_and`     | `"Rubi Rosa"`       | `WHERE column LIKE '%Rubi%' AND column LIKE '%Rosa%'`   |
-  | `:like_or`      | `"Rubi Rosa"`       | `WHERE column LIKE '%Rubi%' OR column LIKE '%Rosa%'`    |
+  | `:like_and`     | `["Rubi", "Rosa"]`  | `WHERE column LIKE '%Rubi%' AND column LIKE '%Rosa%'`   |
+  | `:like_or`      | `["Rubi", "Rosa"]`  | `WHERE column LIKE '%Rubi%' OR column LIKE '%Rosa%'`    |
   | `:ilike`        | `"cyth"`            | `WHERE column ILIKE '%cyth%'`                           |
-  | `:ilike_and`    | `"Rubi Rosa"`       | `WHERE column ILIKE '%Rubi%' AND column ILIKE '%Rosa%'` |
-  | `:ilike_or`     | `"Rubi Rosa"`       | `WHERE column ILIKE '%Rubi%' OR column ILIKE '%Rosa%'`  |
+  | `:ilike_and`    | `["Rubi", "Rosa"]`  | `WHERE column ILIKE '%Rubi%' AND column ILIKE '%Rosa%'` |
+  | `:ilike_or`     | `["Rubi", "Rosa"]`  | `WHERE column ILIKE '%Rubi%' OR column ILIKE '%Rosa%'`  |
   """
   @type op ::
           :==

--- a/lib/flop/operators.ex
+++ b/lib/flop/operators.ex
@@ -200,8 +200,8 @@ defmodule Flop.Operators do
         like(field(r, ^var!(field)), ^substring)
       end
 
-    prelude = prelude(:split_search_text)
     combinator = :and
+    prelude = prelude(:add_wildcards)
 
     {fragment, prelude, combinator}
   end
@@ -212,8 +212,8 @@ defmodule Flop.Operators do
         like(field(r, ^var!(field)), ^substring)
       end
 
-    prelude = prelude(:split_search_text)
     combinator = :or
+    prelude = prelude(:add_wildcards)
 
     {fragment, prelude, combinator}
   end
@@ -224,8 +224,8 @@ defmodule Flop.Operators do
         ilike(field(r, ^var!(field)), ^substring)
       end
 
-    prelude = prelude(:split_search_text)
     combinator = :and
+    prelude = prelude(:add_wildcards)
 
     {fragment, prelude, combinator}
   end
@@ -236,8 +236,8 @@ defmodule Flop.Operators do
         ilike(field(r, ^var!(field)), ^substring)
       end
 
-    prelude = prelude(:split_search_text)
     combinator = :or
+    prelude = prelude(:add_wildcards)
 
     {fragment, prelude, combinator}
   end
@@ -254,9 +254,9 @@ defmodule Flop.Operators do
     end
   end
 
-  defp prelude(:split_search_text) do
+  defp prelude(:add_wildcards) do
     quote do
-      var!(value) = Flop.Misc.split_search_text(var!(value))
+      var!(value) = var!(value) |> Enum.map(&Flop.Misc.add_wildcard/1)
     end
   end
 end

--- a/lib/flop/operators.ex
+++ b/lib/flop/operators.ex
@@ -201,7 +201,7 @@ defmodule Flop.Operators do
       end
 
     combinator = :and
-    prelude = prelude(:try_split_search_text)
+    prelude = prelude(:maybe_split_search_text)
 
     {fragment, prelude, combinator}
   end
@@ -213,7 +213,7 @@ defmodule Flop.Operators do
       end
 
     combinator = :or
-    prelude = prelude(:try_split_search_text)
+    prelude = prelude(:maybe_split_search_text)
 
     {fragment, prelude, combinator}
   end
@@ -225,7 +225,7 @@ defmodule Flop.Operators do
       end
 
     combinator = :and
-    prelude = prelude(:try_split_search_text)
+    prelude = prelude(:maybe_split_search_text)
 
     {fragment, prelude, combinator}
   end
@@ -237,7 +237,7 @@ defmodule Flop.Operators do
       end
 
     combinator = :or
-    prelude = prelude(:try_split_search_text)
+    prelude = prelude(:maybe_split_search_text)
 
     {fragment, prelude, combinator}
   end
@@ -254,10 +254,10 @@ defmodule Flop.Operators do
     end
   end
 
-  defp prelude(:try_split_search_text) do
+  defp prelude(:maybe_split_search_text) do
     quote do
       var!(value) =
-        if is_bitstring(var!(value)) do
+        if is_binary(var!(value)) do
           Flop.Misc.split_search_text(var!(value))
         else
           Enum.map(var!(value), &Flop.Misc.add_wildcard/1)

--- a/lib/flop/operators.ex
+++ b/lib/flop/operators.ex
@@ -201,7 +201,7 @@ defmodule Flop.Operators do
       end
 
     combinator = :and
-    prelude = prelude(:add_wildcards)
+    prelude = prelude(:try_split_search_text)
 
     {fragment, prelude, combinator}
   end
@@ -213,7 +213,7 @@ defmodule Flop.Operators do
       end
 
     combinator = :or
-    prelude = prelude(:add_wildcards)
+    prelude = prelude(:try_split_search_text)
 
     {fragment, prelude, combinator}
   end
@@ -225,7 +225,7 @@ defmodule Flop.Operators do
       end
 
     combinator = :and
-    prelude = prelude(:add_wildcards)
+    prelude = prelude(:try_split_search_text)
 
     {fragment, prelude, combinator}
   end
@@ -237,7 +237,7 @@ defmodule Flop.Operators do
       end
 
     combinator = :or
-    prelude = prelude(:add_wildcards)
+    prelude = prelude(:try_split_search_text)
 
     {fragment, prelude, combinator}
   end
@@ -254,9 +254,14 @@ defmodule Flop.Operators do
     end
   end
 
-  defp prelude(:add_wildcards) do
+  defp prelude(:try_split_search_text) do
     quote do
-      var!(value) = var!(value) |> Enum.map(&Flop.Misc.add_wildcard/1)
+      var!(value) =
+        if is_bitstring(var!(value)) do
+          Flop.Misc.split_search_text(var!(value))
+        else
+          Enum.map(var!(value), &Flop.Misc.add_wildcard/1)
+        end
     end
   end
 end

--- a/lib/flop/schema.ex
+++ b/lib/flop/schema.ex
@@ -185,7 +185,7 @@ defprotocol Flop.Schema do
   ### Filter operator rules
 
   - `:=~`, `:like`, `:like_and`, `:like_or`, `:ilike`, `:ilike_and`,
-    `:ilike_or` - If a string value is passed it will be split at whitespace characters as usual,
+    `:ilike_or` - If a string value is passed, it will be split at whitespace characters as usual,
                   otherwise a list of strings can be passed.
     The filter matches for a value if it matches for any of the fields.
   - `:empty` - Matches if all fields of the compound field are `nil`.

--- a/lib/flop/schema.ex
+++ b/lib/flop/schema.ex
@@ -169,7 +169,14 @@ defprotocol Flop.Schema do
           value: ["margo", "martindale"]
         }]
       }
-
+  or
+      params = %{
+        filters: [%{
+          field: :full_name,
+          op: :ilike_and,
+          value: "margo martindale""
+        }]
+      }
   This would translate to:
 
       WHERE (family_name ilike '%margo%' OR given_name ='%margo%')
@@ -178,7 +185,8 @@ defprotocol Flop.Schema do
   ### Filter operator rules
 
   - `:=~`, `:like`, `:like_and`, `:like_or`, `:ilike`, `:ilike_and`,
-    `:ilike_or` - To match multiple values a list should be passed.
+    `:ilike_or` - If a string value is passed it will be split at whitespace characters as usual,
+                  otherwise a list of strings can be passed.
     The filter matches for a value if it matches for any of the fields.
   - `:empty` - Matches if all fields of the compound field are `nil`.
   - `:not_empty` - Matches if any field of the compound field is not `nil`.

--- a/lib/flop/schema.ex
+++ b/lib/flop/schema.ex
@@ -159,14 +159,14 @@ defprotocol Flop.Schema do
 
       WHERE family_name='margo' OR given_name ='margo'
 
-  Partial matches and splitting of the search term can be achieved with one of
+  Partial matches of the search term can be achieved with one of
   the ilike operators.
 
       params = %{
         filters: [%{
           field: :full_name,
           op: :ilike_and,
-          value: "margo martindale"
+          value: ["margo", "martindale"]
         }]
       }
 
@@ -178,7 +178,7 @@ defprotocol Flop.Schema do
   ### Filter operator rules
 
   - `:=~`, `:like`, `:like_and`, `:like_or`, `:ilike`, `:ilike_and`,
-    `:ilike_or` - The filter value is split at whitespace characters as usual.
+    `:ilike_or` - To match multiple values a list should be passed.
     The filter matches for a value if it matches for any of the fields.
   - `:empty` - Matches if all fields of the compound field are `nil`.
   - `:not_empty` - Matches if any field of the compound field is not `nil`.

--- a/test/flop_test.exs
+++ b/test/flop_test.exs
@@ -357,11 +357,13 @@ defmodule FlopTest do
                 field <- filterable_pet_field(:string),
                 pet <- member_of(pets),
                 value = Pet.get_field(pet, field),
-                search_text <- search_text_list(value) do
-        expected = filter_pets(pets, field, :like_and, search_text)
+                search_text_or_list <- search_text_or_list(value) do
+        expected = filter_pets(pets, field, :like_and, search_text_or_list)
 
         assert query_pets_with_owners(%{
-                 filters: [%{field: field, op: :like_and, value: search_text}]
+                 filters: [
+                   %{field: field, op: :like_and, value: search_text_or_list}
+                 ]
                }) == expected
 
         checkin_checkout()
@@ -374,11 +376,13 @@ defmodule FlopTest do
                 field <- filterable_pet_field(:string),
                 pet <- member_of(pets),
                 value = Pet.get_field(pet, field),
-                search_text <- search_text_list(value) do
-        expected = filter_pets(pets, field, :like_or, search_text)
+                search_text_or_list <- search_text_or_list(value) do
+        expected = filter_pets(pets, field, :like_or, search_text_or_list)
 
         assert query_pets_with_owners(%{
-                 filters: [%{field: field, op: :like_or, value: search_text}]
+                 filters: [
+                   %{field: field, op: :like_or, value: search_text_or_list}
+                 ]
                }) == expected
 
         checkin_checkout()
@@ -391,11 +395,13 @@ defmodule FlopTest do
                 field <- filterable_pet_field(:string),
                 pet <- member_of(pets),
                 value = Pet.get_field(pet, field),
-                search_text <- search_text_list(value) do
-        expected = filter_pets(pets, field, :ilike_and, search_text)
+                search_text_or_list <- search_text_or_list(value) do
+        expected = filter_pets(pets, field, :ilike_and, search_text_or_list)
 
         assert query_pets_with_owners(%{
-                 filters: [%{field: field, op: :ilike_and, value: search_text}]
+                 filters: [
+                   %{field: field, op: :ilike_and, value: search_text_or_list}
+                 ]
                }) == expected
 
         checkin_checkout()
@@ -408,11 +414,13 @@ defmodule FlopTest do
                 field <- filterable_pet_field(:string),
                 pet <- member_of(pets),
                 value = Pet.get_field(pet, field),
-                search_text <- search_text_list(value) do
-        expected = filter_pets(pets, field, :ilike_or, search_text)
+                search_text_or_list <- search_text_or_list(value) do
+        expected = filter_pets(pets, field, :ilike_or, search_text_or_list)
 
         assert query_pets_with_owners(%{
-                 filters: [%{field: field, op: :ilike_or, value: search_text}]
+                 filters: [
+                   %{field: field, op: :ilike_or, value: search_text_or_list}
+                 ]
                }) == expected
 
         checkin_checkout()

--- a/test/flop_test.exs
+++ b/test/flop_test.exs
@@ -357,7 +357,7 @@ defmodule FlopTest do
                 field <- filterable_pet_field(:string),
                 pet <- member_of(pets),
                 value = Pet.get_field(pet, field),
-                search_text <- search_text(value) do
+                search_text <- search_text_list(value) do
         expected = filter_pets(pets, field, :like_and, search_text)
 
         assert query_pets_with_owners(%{
@@ -374,7 +374,7 @@ defmodule FlopTest do
                 field <- filterable_pet_field(:string),
                 pet <- member_of(pets),
                 value = Pet.get_field(pet, field),
-                search_text <- search_text(value) do
+                search_text <- search_text_list(value) do
         expected = filter_pets(pets, field, :like_or, search_text)
 
         assert query_pets_with_owners(%{
@@ -391,7 +391,7 @@ defmodule FlopTest do
                 field <- filterable_pet_field(:string),
                 pet <- member_of(pets),
                 value = Pet.get_field(pet, field),
-                search_text <- search_text(value) do
+                search_text <- search_text_list(value) do
         expected = filter_pets(pets, field, :ilike_and, search_text)
 
         assert query_pets_with_owners(%{
@@ -408,7 +408,7 @@ defmodule FlopTest do
                 field <- filterable_pet_field(:string),
                 pet <- member_of(pets),
                 value = Pet.get_field(pet, field),
-                search_text <- search_text(value) do
+                search_text <- search_text_list(value) do
         expected = filter_pets(pets, field, :ilike_or, search_text)
 
         assert query_pets_with_owners(%{

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -180,10 +180,17 @@ defmodule Flop.Generators do
   end
 
   @doc """
-  Generates a list of search strings consisting of two random substrings from the given
+  Generates a search string consisting of two random substrings
+  or a list of search strings consisting of two random substrings from the given
   string.
   """
-  def search_text_list(s) when is_binary(s) do
+  def search_text_or_list(s) when is_binary(s) do
+    gen all string_or_list <- one_of([search_text(s), search_text_list(s)]) do
+      string_or_list
+    end
+  end
+
+  defp search_text_list(s) when is_binary(s) do
     str_length = String.length(s)
 
     gen all start_at_a <- integer(0..(str_length - 2)),
@@ -203,6 +210,13 @@ defmodule Flop.Generators do
               |> constant(),
             query_value_b != "" do
       [query_value_a, query_value_b]
+    end
+  end
+
+  defp search_text(s) when is_binary(s) do
+    gen all whitespace_character <- member_of(@whitespace),
+            text_list <- search_text_list(s) do
+      Enum.join(text_list, whitespace_character)
     end
   end
 end

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -180,10 +180,10 @@ defmodule Flop.Generators do
   end
 
   @doc """
-  Generates a search string consisting of two random substrings from the given
+  Generates a list of search strings consisting of two random substrings from the given
   string.
   """
-  def search_text(s) when is_binary(s) do
+  def search_text_list(s) when is_binary(s) do
     str_length = String.length(s)
 
     gen all start_at_a <- integer(0..(str_length - 2)),
@@ -201,9 +201,8 @@ defmodule Flop.Generators do
               |> String.slice(start_at_b..end_at_b)
               |> String.trim()
               |> constant(),
-            query_value_b != "",
-            whitespace_character <- member_of(@whitespace) do
-      Enum.join([query_value_a, query_value_b], whitespace_character)
+            query_value_b != "" do
+      [query_value_a, query_value_b]
     end
   end
 end

--- a/test/support/test_util.ex
+++ b/test/support/test_util.ex
@@ -108,13 +108,33 @@ defmodule Flop.TestUtil do
     &(String.downcase(&1) =~ v)
   end
 
+  defp matches?(:like_and, v) when is_bitstring(v) do
+    values = String.split(v)
+    &Enum.all?(values, fn v -> &1 =~ v end)
+  end
+
   defp matches?(:like_and, v), do: &Enum.all?(v, fn v -> &1 =~ v end)
 
+  defp matches?(:like_or, v) when is_bitstring(v) do
+    values = String.split(v)
+    &Enum.any?(values, fn v -> &1 =~ v end)
+  end
+
   defp matches?(:like_or, v), do: &Enum.any?(v, fn v -> &1 =~ v end)
+
+  defp matches?(:ilike_and, v) when is_bitstring(v) do
+    values = v |> String.downcase() |> String.split()
+    &Enum.all?(values, fn v -> String.downcase(&1) =~ v end)
+  end
 
   defp matches?(:ilike_and, v) do
     values = Enum.map(v, &String.downcase/1)
     &Enum.all?(values, fn v -> String.downcase(&1) =~ v end)
+  end
+
+  defp matches?(:ilike_or, v) when is_bitstring(v) do
+    values = v |> String.downcase() |> String.split()
+    &Enum.any?(values, fn v -> String.downcase(&1) =~ v end)
   end
 
   defp matches?(:ilike_or, v) do

--- a/test/support/test_util.ex
+++ b/test/support/test_util.ex
@@ -108,21 +108,21 @@ defmodule Flop.TestUtil do
     &(String.downcase(&1) =~ v)
   end
 
-  defp matches?(:like_and, v) when is_bitstring(v) do
+  defp matches?(:like_and, v) when is_binary(v) do
     values = String.split(v)
     &Enum.all?(values, fn v -> &1 =~ v end)
   end
 
   defp matches?(:like_and, v), do: &Enum.all?(v, fn v -> &1 =~ v end)
 
-  defp matches?(:like_or, v) when is_bitstring(v) do
+  defp matches?(:like_or, v) when is_binary(v) do
     values = String.split(v)
     &Enum.any?(values, fn v -> &1 =~ v end)
   end
 
   defp matches?(:like_or, v), do: &Enum.any?(v, fn v -> &1 =~ v end)
 
-  defp matches?(:ilike_and, v) when is_bitstring(v) do
+  defp matches?(:ilike_and, v) when is_binary(v) do
     values = v |> String.downcase() |> String.split()
     &Enum.all?(values, fn v -> String.downcase(&1) =~ v end)
   end
@@ -132,7 +132,7 @@ defmodule Flop.TestUtil do
     &Enum.all?(values, fn v -> String.downcase(&1) =~ v end)
   end
 
-  defp matches?(:ilike_or, v) when is_bitstring(v) do
+  defp matches?(:ilike_or, v) when is_binary(v) do
     values = v |> String.downcase() |> String.split()
     &Enum.any?(values, fn v -> String.downcase(&1) =~ v end)
   end

--- a/test/support/test_util.ex
+++ b/test/support/test_util.ex
@@ -108,23 +108,17 @@ defmodule Flop.TestUtil do
     &(String.downcase(&1) =~ v)
   end
 
-  defp matches?(:like_and, v) do
-    values = String.split(v)
-    &Enum.all?(values, fn v -> &1 =~ v end)
-  end
+  defp matches?(:like_and, v), do: &Enum.all?(v, fn v -> &1 =~ v end)
 
-  defp matches?(:like_or, v) do
-    values = String.split(v)
-    &Enum.any?(values, fn v -> &1 =~ v end)
-  end
+  defp matches?(:like_or, v), do: &Enum.any?(v, fn v -> &1 =~ v end)
 
   defp matches?(:ilike_and, v) do
-    values = v |> String.downcase() |> String.split()
+    values = Enum.map(v, &String.downcase/1)
     &Enum.all?(values, fn v -> String.downcase(&1) =~ v end)
   end
 
   defp matches?(:ilike_or, v) do
-    values = v |> String.downcase() |> String.split()
+    values = Enum.map(v, &String.downcase/1)
     &Enum.any?(values, fn v -> String.downcase(&1) =~ v end)
   end
 


### PR DESCRIPTION
**Change `like_and`/`like_or`/`ilike_and`/`ilike_or` interface**

This PR is a request to change the interface of the `like_and`/`like_or`/`ilike_and`/`ilike_or` filters.
Currently the argument (string) provided in input is split using the `space` as a separator, the result will be used to match on the field.

But there are cases when it is desirable to search for strings that do contain spaces among them so that we can match exactly that pattern, and now this is not possible.

This PR  covers this new scenario by providing to the filters a list of strings instead of just one string, which will be used verbatim in the `like`/`ilike` generated query

es:
```elixir 
 %{
        filters: [%{
          field: :name,
          op: :ilike_or,
          value: ["blanche burgundy", "margarete burgundy"]
        }]
      }

#this will generate something like this
dynamic([r],
 ^true and (^false or like(r.name, ^"%blanche  burgundy%") or like(r.name, ^"%margarete burgundy%"))

#instead of what would happen now 
dynamic([r],
 ^true and (^false or like(r.name, ^"%blanche%") 
                       or like(r.name, ^"%margarete%")
                      or like(r.name, ^"%burgundy%") 
                      or like(r.name, ^"%burgundy%"))
```

Thanks in advance for your time. 

**Checklist**

- [x] I modified existing tests that cover my proposed changes.
- [x] I updated the documentation related to my changes.
