### PR TITLE
Improve compound fields documentation.

### DIFF
--- a/cheatsheets/schema.cheatmd
+++ b/cheatsheets/schema.cheatmd
@@ -112,8 +112,8 @@ defmodule User do
 
   @derive {
     Flop.Schema,
-    filterable: [:name, :species],
-    sortable: [:name, :age],
+    filterable: [:full_name],
+    sortable: [:full_name],
     compound_fields: [
       full_name: [:family_name, :given_name]
     ]

--- a/lib/flop/schema.ex
+++ b/lib/flop/schema.ex
@@ -150,17 +150,17 @@ defprotocol Flop.Schema do
       params = %{
         filters: [%{
           field: :full_name,
-          op: :==,
+          op: :like,
           value: "margo"
         }]
       }
 
   This would translate to:
 
-      WHERE family_name='margo' OR given_name ='margo'
+      WHERE family_name like '%margo%' OR given_name like '%margo%'
 
   Partial matches of the search term can be achieved with one of
-  the ilike operators.
+  the like operators.
 
       params = %{
         filters: [%{
@@ -174,31 +174,32 @@ defprotocol Flop.Schema do
         filters: [%{
           field: :full_name,
           op: :ilike_and,
-          value: "margo martindale""
+          value: "margo martindale"
         }]
       }
   This would translate to:
 
-      WHERE (family_name ilike '%margo%' OR given_name ='%margo%')
-      AND (family_name ilike '%martindale%' OR given_name ='%martindale%')
+      WHERE (family_name ilike '%margo%' OR given_name ilike '%margo%')
+      AND (family_name ilike '%martindale%' OR given_name ilike '%martindale%')
 
   ### Filter operator rules
 
-  - `:=~`, `:like`, `:not_like`, `:like_and`, `:like_or`, `:ilike`, `:not_ilike`, `:ilike_and`,
-    `:ilike_or` - If a string value is passed, it will be split at whitespace
-    characters and each segment will be checked for. If a list of strings is
-    passed, the individual strings are not split. The filter matches for a value
+  - `:=~` `:like` `:not_like` `:like_and` `:like_or` `:ilike` `:not_ilike` `:ilike_and` `:ilike_or`  
+    If a string value is passed it will be split at whitespace
+    characters and each segment will be checked separately. If a list of strings is
+    passed the individual strings are not split. The filter matches for a value
     if it matches for any of the fields.
-  - `:empty` - Matches if all fields of the compound field are `nil`.
-  - `:not_empty` - Matches if any field of the compound field is not `nil`.
-  - `:==`, `:!=`, `:<=`, `:<`, `:>=`, `:>`, `:in`, `:not_in`, `:contains`
-    `:not_contains`
-  - The filter value is normalized by splitting the string at whitespaces and
+  - `:empty`  
+    Matches if all fields of the compound field are `nil`.
+  - `:not_empty`  
+    Matches if any field of the compound field is not `nil`.
+  - `:==` `:!=` `:<=` `:<` `:>=` `:>` `:in` `:not_in` `:contains` `:not_contains`  
+    ** These filter operators are ignored for compound fields at the moment.
+    This will be added in a future version.**  
+    The filter value is normalized by splitting the string at whitespaces and
     joining it with a space. The values of all fields of the compound field are
     split by whitespace character and joined with a space, and the resulting
-    values are joined with a space again. **This will be added in a future
-    version. These filter operators are ignored for compound fields at the
-    moment.**
+    values are joined with a space again.
 
   ### Sorting
 


### PR DESCRIPTION
Since the `:==` is not yet supported for compound fields, I think it's better to give an example with one of the _like_ operators.

The cheatsheet section on compound fields was a bit confusing, so I tried to clean it up. I improved the layout and the wording of how the operators work with compound fields.