### PR TITLE
Add `:count` option to `Flop.count/3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added the `:count` override option to `Flop.count/3`
+
 ## [0.20.0] - 2023-03-21
 
 ### Added

--- a/lib/flop.ex
+++ b/lib/flop.ex
@@ -391,6 +391,9 @@ defmodule Flop do
   - `:count_query` - Allows you to set a separate base query for counting. Can
     only be passed as an option to one of the query functions. See
     `Flop.validate_and_run/3` and `Flop.count/3`.
+  - `:count` - Allows you to set the count, useful for when the count is already
+    computed elsewhere. Can only be passed as an option to one of the query
+    functions. See `Flop.validate_and_run/3` and `Flop.count/3`.
   - `:pagination` (boolean) - Can be set to `false` to silently ignore
     pagination parameters.
   - `:pagination_types` - Defines which pagination types are allowed. Parameters
@@ -452,6 +455,7 @@ defmodule Flop do
           | {:for, module}
           | {:max_limit, pos_integer | false}
           | {:count_query, Ecto.Queryable.t()}
+          | {:count, integer}
           | {:ordering, boolean}
           | {:pagination, boolean}
           | {:pagination_types, [pagination_type()]}

--- a/lib/flop.ex
+++ b/lib/flop.ex
@@ -751,6 +751,11 @@ defmodule Flop do
 
   The filter parameters of the given Flop are applied to the custom count query.
 
+  If for some reason you already have the count, you can pass it as the `:count`
+  option.
+
+      count(query, %Flop{}, count: 42)
+
   This function does _not_ validate or apply default parameters to the given
   Flop struct. Be sure to validate any user-generated parameters with
   `validate/2` or `validate!/2` before passing them to this function.
@@ -759,8 +764,12 @@ defmodule Flop do
   @doc group: :queries
   @spec count(Queryable.t(), Flop.t(), [option()]) :: non_neg_integer
   def count(q, %Flop{} = flop, opts \\ []) do
-    q = opts[:count_query] || q
-    apply_on_repo(:aggregate, "count", [filter(q, flop, opts), :count], opts)
+    if count = opts[:count] do
+      count
+    else
+      q = opts[:count_query] || q
+      apply_on_repo(:aggregate, "count", [filter(q, flop, opts), :count], opts)
+    end
   end
 
   @doc """

--- a/test/flop_test.exs
+++ b/test/flop_test.exs
@@ -778,6 +778,25 @@ defmodule FlopTest do
       assert Flop.count(Pet, flop, count_query: where(Pet, name: "A")) == 6
       assert Flop.count(Pet, flop, count_query: where(Pet, name: "B")) == 5
     end
+
+    test "allows overriding the count itself" do
+      _matching_pets = insert_list(6, :pet, age: 5, name: "A")
+      _more_matching_pets = insert_list(5, :pet, age: 5, name: "B")
+      _non_matching_pets = insert_list(4, :pet, age: 6)
+
+      flop = %Flop{
+        limit: 2,
+        offset: 2,
+        order_by: [:age],
+        filters: [%Filter{field: :age, op: :<=, value: 5}]
+      }
+
+      # default query
+      assert Flop.count(Pet, flop) == 11
+
+      # custom count
+      assert Flop.count(Pet, flop, count: 6) == 6
+    end
   end
 
   describe "meta/3" do


### PR DESCRIPTION
**Description**

Add `:count` option to `Flop.count/3`. This is useful when there already is a count, and in my particular case, I'm using [`ecto3_mnesia`](https://gitlab.com/patatoid/ecto3_mnesia) and it has compatibility issues with aggregates.

**Checklist**

- [x] I added tests that cover my proposed changes.
- [x] I updated the documentation related to my changes (if applicable).
