### PR TITLE
Logger.warn => Logger.warning to avoid elixir 1.15 compile warnings

### DIFF
--- a/lib/flop/builder.ex
+++ b/lib/flop/builder.ex
@@ -148,7 +148,7 @@ defmodule Flop.Builder do
     # value = value |> String.split() |> Enum.join(" ")
     # filter = %{filter | value: value}
     # compare value with concatenated fields
-    Logger.warn(
+    Logger.warning(
       "Flop: Operator '#{op}' not supported for compound fields. Ignored."
     )
 

--- a/lib/flop/schema.ex
+++ b/lib/flop/schema.ex
@@ -1114,7 +1114,7 @@ defimpl Flop.Schema, for: Any do
     for {compound_field, _fields} <- compound_fields do
       quote do
         def cursor_dynamic(_, [{_, unquote(compound_field)}], _) do
-          Logger.warn(
+          Logger.warning(
             "Flop: Cursor pagination is not supported for compound fields. Ignored."
           )
 
@@ -1126,7 +1126,7 @@ defimpl Flop.Schema, for: Any do
               [{_, unquote(compound_field)} | tail],
               cursor
             ) do
-          Logger.warn(
+          Logger.warning(
             "Flop: Cursor pagination is not supported for compound fields. Ignored."
           )
 


### PR DESCRIPTION
**Description**

Since Elixir 1.15 the use of `Logger.warn` [is deprecated](https://hexdocs.pm/elixir/1.15.0-rc.1/changelog.html#4-hard-deprecations). When deriving `Flop.Schema` this results in compile time warnings in the module deriving `Flop.Schema`. This in turn makes compilation fail when running with `--warnings-as-errors`.
