### PR TITLE
more improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,22 @@
   field type and operator, instead of allowing any arbitrary filter value. By
   doing this, invalid filter values will now result in validation errors instead
   of causing cast errors.
-- The options for deriving the `Flop.Schema` protocol are now stricter validated
-  with `NimbleOptions`.
+- The options for both deriving the `Flop.Schema` protocol and for `use Flop`
+  are now stricter validated with `NimbleOptions`.
 - `Flop.Cursor.encode/1` now explicitly sets the minor version option for
   `:erlang.term_to_binary/2` to `2`, which is the new default in OTP 26.
+
+### Deprecated
+
+- The tuple syntax for join fields has been deprecated. Use a keyword list
+  instead.
+
+### Fixed
+
+- When the `replace_invalid_params` option was set to `true`, cast errors for
+  pagination and sorting parameters were still causing validation errors instead
+  of defaulting to valid parameters.
+- Fixed type specification for `Flop.Filter.allowed_operators/1`.
 
 ### Upgrade notes
 
@@ -58,12 +70,20 @@ The dynamic casting of filter values might have some effects on your code:
 Please review the new "Ecto type option" section in the `Flop.Schema` module
 documentation.
 
-### Fixed
+#### Join field syntax
 
-- When the `replace_invalid_params` option was set to `true`, cast errors for
-  pagination and sorting parameters were still causing validation errors instead
-  of defaulting to valid parameters.
-- Fixed type specification for `Flop.Filter.allowed_operators/1`.
+If you are using tuples to define join fields when you derive `Flop.Schema`,
+update the configuration to use keyword lists instead:
+
+```diff
+@derive {
+  Flop.Schema,
+  join_fields: [
+-    owner_name: {:owner, :name}
++    owner_name: [binding: :owner, field: :name]
+  ]
+}
+```
 
 ## [0.20.3] - 2023-06-23
 
@@ -145,6 +165,7 @@ documentation.
 - Added `ecto_type` option to join fields.
 - Added `not_like` and `not_ilike` filter operators.
 - Added a cheatsheet for schema configuration.
+- Added `opts` field to `Flop.Meta` struct.
 
 ### Changed
 
@@ -156,7 +177,6 @@ documentation.
   new `ecto_type` option. If the option is not set, the function returns all
   operators as before. For compound fields, only the supported operators are
   returned.
-- Added `opts` field to `Flop.Meta` struct.
 
 ## [0.18.4] - 2022-11-17
 

--- a/lib/flop.ex
+++ b/lib/flop.ex
@@ -288,6 +288,7 @@ defmodule Flop do
   alias Flop.CustomTypes.ExistingAtom
   alias Flop.Filter
   alias Flop.Meta
+  alias Flop.NimbleSchemas
 
   require Ecto.Query
   require Logger
@@ -295,27 +296,7 @@ defmodule Flop do
   @default_opts [default_limit: 50, max_limit: 1000]
 
   defmacro __using__(opts) do
-    known_options = [
-      :cursor_value_func,
-      :default_limit,
-      :default_pagination_type,
-      :filtering,
-      :max_limit,
-      :pagination,
-      :pagination_types,
-      :query_opts,
-      :repo
-    ]
-
-    unknown_options = Keyword.keys(opts) -- known_options
-
-    if unknown_options != [] do
-      # coveralls-ignore-start
-      raise "unknown option(s) for Flop: #{inspect(unknown_options)}"
-      # coveralls-ignore-stop
-    end
-
-    opts = Keyword.merge(@default_opts, opts)
+    opts = NimbleOptions.validate!(opts, NimbleSchemas.__backend_option__())
 
     quote do
       @doc false

--- a/lib/flop/nimble_schemas.ex
+++ b/lib/flop/nimble_schemas.ex
@@ -1,6 +1,34 @@
 defmodule Flop.NimbleSchemas do
   @moduledoc false
 
+  @backend_option [
+    cursor_value_func: [type: {:fun, 2}],
+    default_limit: [type: :integer, default: 50],
+    max_limit: [type: :integer, default: 1000],
+    default_pagination_type: [
+      type: {:in, [:offset, :page, :first, :last]},
+      default: :offset
+    ],
+    filtering: [
+      type: :boolean,
+      default: true
+    ],
+    ordering: [
+      type: :boolean,
+      default: true
+    ],
+    pagination: [
+      type: :boolean,
+      default: true
+    ],
+    pagination_types: [
+      type: {:list, {:in, [:offset, :page, :first, :last]}},
+      default: [:offset, :page, :first, :last]
+    ],
+    repo: [],
+    query_opts: [type: :keyword_list]
+  ]
+
   @schema_option [
     filterable: [type: {:list, :atom}, required: true],
     sortable: [type: {:list, :atom}, required: true],
@@ -78,8 +106,9 @@ defmodule Flop.NimbleSchemas do
     ]
   ]
 
+  @backend_option NimbleOptions.new!(@backend_option)
   @schema_option NimbleOptions.new!(@schema_option)
 
-  @doc false
+  def __backend_option__, do: @backend_option
   def __schema_option__, do: @schema_option
 end

--- a/lib/flop/schema.ex
+++ b/lib/flop/schema.ex
@@ -766,7 +766,12 @@ defimpl Flop.Schema, for: Any do
   """
   # credo:disable-for-next-line
   defmacro __deriving__(module, struct, options) do
-    NimbleOptions.validate!(options, NimbleSchemas.__schema_option__())
+    options =
+      NimbleOptions.validate!(
+        options,
+        NimbleSchemas.__schema_option__()
+      )
+
     validate_options!(options, struct)
 
     filterable_fields = Keyword.get(options, :filterable)

--- a/lib/flop/schema.ex
+++ b/lib/flop/schema.ex
@@ -271,18 +271,6 @@ defprotocol Flop.Schema do
     filter values, and also to treat empty arrays and empty maps as empty values
     depending on the type. See also `Ecto type option` section below.
 
-  There is a short syntax which you can use if you only want to specify the
-  binding and the field:
-
-      @derive {
-        Flop.Schema,
-        filterable: [:pet_species],
-        sortable: [:pet_species],
-        join_fields: [pet_species: {:pets, :species}]
-      }
-
-  This syntax is not recommended anymore and should be viewed as deprecated.
-
   In order to retrieve the pagination cursor value for a join field, Flop needs
   to know how to get the field value from the struct that is returned from the
   database. `Flop.Schema.get_field/2` is used for that. By default, Flop assumes
@@ -755,6 +743,7 @@ end
 
 defimpl Flop.Schema, for: Any do
   alias Flop.NimbleSchemas
+  require Logger
 
   @instructions """
   Flop.Schema protocol must always be explicitly implemented.
@@ -1100,6 +1089,10 @@ defimpl Flop.Schema, for: Any do
     opts =
       case opts do
         {binding, field} ->
+          Logger.warning(
+            "The tuple syntax for defining join fields has been deprecated. Use a keyword list instead."
+          )
+
           %{
             binding: binding,
             field: field,

--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,7 @@ defmodule Flop.MixProject do
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},
       {:ex_machina, "~> 2.4", only: :test},
       {:excoveralls, "~> 0.10", only: :test},
-      {:nimble_options, "~> 1.0.0"},
+      {:nimble_options, "~> 1.0"},
       {:postgrex, ">= 0.0.0", only: :test},
       {:stream_data, "~> 0.5", only: [:dev, :test]}
     ]


### PR DESCRIPTION
- depend on nimble_options ~> 1.0
- deprecate tuple syntax for join fields
- assign validated options
- validate options for `use Flop` with NimbleOptions
- update changelog
