### PR TITLE
feat: allow sending string type in field param

### DIFF
--- a/lib/flop/filter.ex
+++ b/lib/flop/filter.ex
@@ -236,6 +236,9 @@ defmodule Flop.Filter do
 
       iex> allowed_operators(Pet, :age)
       [:==, :!=, :empty, :not_empty, :<=, :<, :>=, :>, :in, :not_in]
+
+      iex> allowed_operators(Pet, "age")
+      [:==, :!=, :empty, :not_empty, :<=, :<, :>=, :>, :in, :not_in]
   """
   @spec allowed_operators(atom, atom) :: [op]
   def allowed_operators(module, field)

--- a/lib/flop/filter.ex
+++ b/lib/flop/filter.ex
@@ -248,21 +248,14 @@ defmodule Flop.Filter do
     |> allowed_operators()
   end
 
-  defp get_field_info(module, field) when is_atom(field) do
+  defp get_field_info(module, field) do
     struct = struct(module)
 
     if Flop.Schema.impl_for(struct) != Flop.Schema.Any do
-      Flop.Schema.field_info(struct, field)
-    else
-      module.__schema__(:type, field)
-    end
-  end
-
-  defp get_field_info(module, field) when is_binary(field) do
-    struct = struct(module)
-
-    if Flop.Schema.impl_for(struct) != Flop.Schema.Any do
-      Flop.Schema.field_info(struct, String.to_atom(field))
+      case is_binary(field) do
+        true -> Flop.Schema.field_info(struct, String.to_atom(field))
+        false -> Flop.Schema.field_info(struct, field)
+      end
     else
       module.__schema__(:type, field)
     end

--- a/lib/flop/filter.ex
+++ b/lib/flop/filter.ex
@@ -253,7 +253,7 @@ defmodule Flop.Filter do
 
     if Flop.Schema.impl_for(struct) != Flop.Schema.Any do
       case is_binary(field) do
-        true -> Flop.Schema.field_info(struct, String.to_atom(field))
+        true -> Flop.Schema.field_info(struct, String.to_existing_atom(field))
         false -> Flop.Schema.field_info(struct, field)
       end
     else

--- a/lib/flop/filter.ex
+++ b/lib/flop/filter.ex
@@ -239,17 +239,27 @@ defmodule Flop.Filter do
   """
   @spec allowed_operators(atom, atom) :: [op]
   def allowed_operators(module, field)
-      when is_atom(module) and is_atom(field) do
+      when is_atom(module) and is_atom(field) or is_binary(field) do
     module
     |> get_field_info(field)
     |> allowed_operators()
   end
 
-  defp get_field_info(module, field) do
+  defp get_field_info(module, field) when is_atom(field) do
     struct = struct(module)
 
     if Flop.Schema.impl_for(struct) != Flop.Schema.Any do
       Flop.Schema.field_info(struct, field)
+    else
+      module.__schema__(:type, field)
+    end
+  end
+
+  defp get_field_info(module, field) when is_binary(field) do
+    struct = struct(module)
+
+    if Flop.Schema.impl_for(struct) != Flop.Schema.Any do
+      Flop.Schema.field_info(struct, String.to_atom(field))
     else
       module.__schema__(:type, field)
     end


### PR DESCRIPTION
Added function and guard to check if the `field` in allowed_operators is a string or atom.

Issue: https://github.com/woylie/flop/issues/420