### PR TITLE
Pagination ignore filters bug

### DIFF
--- a/lib/flop/validation.ex
+++ b/lib/flop/validation.ex
@@ -366,21 +366,21 @@ defmodule Flop.Validation do
     end
   end
 
-  defp get_pagination_type(%Changeset{changes: changes}, opts) do
+  defp get_pagination_type(%Changeset{} = changeset, opts) do
     cond do
-      any_set?(changes, :first, :after) -> :first
-      any_set?(changes, :last, :before) -> :last
-      any_set?(changes, :page, :page_size) -> :page
-      any_set?(changes, :limit, :offset) -> :offset
+      any_change_or_errors?(changeset, :first, :after) -> :first
+      any_change_or_errors?(changeset, :last, :before) -> :last
+      any_change_or_errors?(changeset, :page, :page_size) -> :page
+      any_change_or_errors?(changeset, :limit, :offset) -> :offset
       true -> Flop.get_option(:default_pagination_type, opts)
     end
   end
 
-  defp any_set?(%{} = map, field_a, field_b) do
-    case map do
+  defp any_change_or_errors?(%Changeset{changes: changes, errors: errors}, field_a, field_b) do
+    case changes do
       %{^field_a => value} when not is_nil(value) -> true
       %{^field_b => value} when not is_nil(value) -> true
-      _ -> false
+      _ -> Keyword.has_key?(errors, field_a) || Keyword.has_key?(errors, field_b)
     end
   end
 

--- a/lib/flop/validation.ex
+++ b/lib/flop/validation.ex
@@ -376,11 +376,20 @@ defmodule Flop.Validation do
     end
   end
 
-  defp any_change_or_errors?(%Changeset{changes: changes, errors: errors}, field_a, field_b) do
+  defp any_change_or_errors?(
+         %Changeset{changes: changes, errors: errors},
+         field_a,
+         field_b
+       ) do
     case changes do
-      %{^field_a => value} when not is_nil(value) -> true
-      %{^field_b => value} when not is_nil(value) -> true
-      _ -> Keyword.has_key?(errors, field_a) || Keyword.has_key?(errors, field_b)
+      %{^field_a => value} when not is_nil(value) ->
+        true
+
+      %{^field_b => value} when not is_nil(value) ->
+        true
+
+      _ ->
+        Keyword.has_key?(errors, field_a) || Keyword.has_key?(errors, field_b)
     end
   end
 

--- a/test/flop/validation_test.exs
+++ b/test/flop/validation_test.exs
@@ -264,7 +264,7 @@ defmodule Flop.ValidationTest do
     end
 
     test "replaces malformed page with replace_invalid_params" do
-      params = %{page: "a", page_size: 10}
+      params = %{page: "a"}
 
       assert {:ok, %Flop{page: 1}} =
                validate(params, replace_invalid_params: true)


### PR DESCRIPTION
### Description
Found a bug where invalid pagination params weren't being ignored even though `replace_invalid_params` is set to true. 

This is because the validation checks the pagination type by looking at the changes in the changeset. However, if the field looking for has an error, then the changeset wont show any changes.

This fix will update `get_pagination_type/2` to infer the type by also checking the changeset errors.

### Checklist
- [x] Updated a test to reflect this.
