### PR TITLE
Basic "or" ability for Filter.

### DIFF
--- a/lib/flop/adapter.ex
+++ b/lib/flop/adapter.ex
@@ -17,6 +17,8 @@ defmodule Flop.Adapter do
             when adapter_opts: map,
                  field: atom
 
+  @callback merge_query(queryable, queryable) :: queryable
+
   @callback apply_filter(queryable, Flop.Filter.t(), struct, keyword) ::
               queryable
 


### PR DESCRIPTION
This is just a draft PR to share my implementation of supporting 'or' filters.  
It works, but is far from done.  There are most likely edge cases where this will not work, specifically it will not work when using custom field info.

Filter:
```
    flop_params = %{
      filters: [
        %{field: :active, op: :==, value: true},
        %{or: 1, field: :valid_start, op: :empty, value: true},
        %{or: 1, field: :valid_start, op: :<=, value: now},
        %{or: 2, field: :valid_end, op: :empty, value: true},
        %{or: 2, field: :valid_end, op: :>=, value: now}
      ]
    }
```

Will generage:
```
SELECT count(*) FROM "redemptions" AS r0 WHERE  (((r0."valid_start" IS NULL) = $2) OR (r0."valid_start" <= $3)) AND (((r0."valid_end" IS NULL) = $4) OR (r0."valid_end" >= $5)) AND (r0."active" = $6) [true, ~U[2023-04-28 16:04:00.549945Z], true, ~U[2023-04-28 16:04:00.549945Z], true]
```