### PR TITLE
Use Ecto.ParameterizedType.init/2 to support Ecto 3.12

### DIFF
--- a/lib/flop/schema.ex
+++ b/lib/flop/schema.ex
@@ -970,7 +970,7 @@ defimpl Flop.Schema, for: Any do
           end
 
         %{ecto_type: {:ecto_enum, values}} ->
-          type = {:parameterized, Ecto.Enum, Ecto.Enum.init(values: values)}
+          type = Ecto.ParameterizedType.init(Ecto.Enum, values: values)
           field_info = %{field_info | ecto_type: type}
 
           quote do


### PR DESCRIPTION
Ecto 3.12 [changed internal representation of parameterized types](https://hexdocs.pm/ecto/changelog.html#potential-incompatibilities). This PR contains the minimal changes to fix incompatibility. The change is backwards compatible as `Ecto.ParameterizedType.init/2` existed before.

Additionally, Flop might want to change its own interface to mirror this change (e.g. from `ecto_type: {:parameterized, Ecto.Enum, Ecto.Enum.init(values: [:one, :two])}` to `ecto_type: {:parameterized, {Ecto.Enum, Ecto.Enum.init(values: [:one, :two])}}`), but my goal here was to just unblock upgrading to ecto 3.12