### PR TITLE
Change docs and tests to use new style parameterized types

### DIFF
--- a/lib/flop/custom_types/any.ex
+++ b/lib/flop/custom_types/any.ex
@@ -17,5 +17,5 @@ defmodule Flop.CustomTypes.Any do
   def type, do: :string
   def load(_), do: :error
   def dump(_), do: :error
-  # coveralls-ignore-end
+  # coveralls-ignore-stop
 end

--- a/lib/flop/custom_types/existing_atom.ex
+++ b/lib/flop/custom_types/existing_atom.ex
@@ -20,5 +20,5 @@ defmodule Flop.CustomTypes.ExistingAtom do
   def type, do: :string
   def load(_), do: :error
   def dump(_), do: :error
-  # coveralls-ignore-end
+  # coveralls-ignore-stop
 end

--- a/lib/flop/custom_types/like.ex
+++ b/lib/flop/custom_types/like.ex
@@ -24,5 +24,5 @@ defmodule Flop.CustomTypes.Like do
   def type, do: :string
   def load(_), do: :error
   def dump(_), do: :error
-  # coveralls-ignore-end
+  # coveralls-ignore-stop
 end

--- a/lib/flop/filter.ex
+++ b/lib/flop/filter.ex
@@ -368,6 +368,22 @@ defmodule Flop.Filter do
     ]
   end
 
+  # for backward compatibility with Ecto < 3.12.0
+  defp get_allowed_operators({:parameterized, Ecto.Enum, _}) do
+    [
+      :==,
+      :!=,
+      :empty,
+      :not_empty,
+      :<=,
+      :<,
+      :>=,
+      :>,
+      :in,
+      :not_in
+    ]
+  end
+
   defp get_allowed_operators(_) do
     [
       :==,

--- a/lib/flop/filter.ex
+++ b/lib/flop/filter.ex
@@ -275,14 +275,19 @@ defmodule Flop.Filter do
   end
 
   def allowed_operators(%FieldInfo{ecto_type: ecto_type}) do
-    ecto_type |> expand_type() |> allowed_operators()
+    ecto_type |> expand_type() |> get_allowed_operators()
   end
 
-  def allowed_operators(type) when type in [:decimal, :float, :id, :integer] do
+  def allowed_operators(type) do
+    type |> expand_type() |> get_allowed_operators()
+  end
+
+  defp get_allowed_operators(type)
+       when type in [:decimal, :float, :id, :integer] do
     [:==, :!=, :empty, :not_empty, :<=, :<, :>=, :>, :in, :not_in]
   end
 
-  def allowed_operators(type) when type in [:binary_id, :string] do
+  defp get_allowed_operators(type) when type in [:binary_id, :string] do
     [
       :==,
       :!=,
@@ -306,11 +311,11 @@ defmodule Flop.Filter do
     ]
   end
 
-  def allowed_operators(:boolean) do
+  defp get_allowed_operators(:boolean) do
     [:==, :!=, :=~, :empty, :not_empty]
   end
 
-  def allowed_operators({:array, _}) do
+  defp get_allowed_operators({:array, _}) do
     [
       :==,
       :!=,
@@ -327,28 +332,28 @@ defmodule Flop.Filter do
     ]
   end
 
-  def allowed_operators({:map, _}) do
+  defp get_allowed_operators({:map, _}) do
     [:==, :!=, :empty, :not_empty, :in, :not_in]
   end
 
-  def allowed_operators(:map) do
+  defp get_allowed_operators(:map) do
     [:==, :!=, :empty, :not_empty, :in, :not_in]
   end
 
-  def allowed_operators(type)
-      when type in [
-             :date,
-             :time,
-             :time_usec,
-             :naive_datetime,
-             :naive_datetime_usec,
-             :utc_datetime,
-             :utc_datetime_usec
-           ] do
+  defp get_allowed_operators(type)
+       when type in [
+              :date,
+              :time,
+              :time_usec,
+              :naive_datetime,
+              :naive_datetime_usec,
+              :utc_datetime,
+              :utc_datetime_usec
+            ] do
     [:==, :!=, :empty, :not_empty, :<=, :<, :>=, :>, :in, :not_in]
   end
 
-  def allowed_operators({:parameterized, {Ecto.Enum, _}}) do
+  defp get_allowed_operators({:parameterized, {Ecto.Enum, _}}) do
     [
       :==,
       :!=,
@@ -363,7 +368,7 @@ defmodule Flop.Filter do
     ]
   end
 
-  def allowed_operators(_) do
+  defp get_allowed_operators(_) do
     [
       :==,
       :!=,

--- a/lib/flop/filter.ex
+++ b/lib/flop/filter.ex
@@ -195,7 +195,7 @@ defmodule Flop.Filter do
   end
 
   defp expand_type({:ecto_enum, values}) do
-    {:parameterized, Ecto.Enum, Ecto.Enum.init(values: values)}
+    Ecto.ParameterizedType.init(Ecto.Enum, values: values)
   end
 
   defp expand_type(type), do: type
@@ -348,7 +348,7 @@ defmodule Flop.Filter do
     [:==, :!=, :empty, :not_empty, :<=, :<, :>=, :>, :in, :not_in]
   end
 
-  def allowed_operators({:parameterized, Ecto.Enum, _}) do
+  def allowed_operators({:parameterized, {Ecto.Enum, _}}) do
     [
       :==,
       :!=,

--- a/lib/flop/schema.ex
+++ b/lib/flop/schema.ex
@@ -489,7 +489,7 @@ defprotocol Flop.Schema do
 
   For parameterized types, use the following syntax:
 
-  - `ecto_type: {:parameterized, Ecto.Enum, Ecto.Enum.init(values: [:one, :two])}`
+  - `ecto_type: Ecto.ParameterizedType.init(Ecto.Enum, values: [:one, :two])`
 
   If you're working with `Ecto.Enum` types, you can use a more convenient
   syntax:
@@ -613,7 +613,7 @@ defprotocol Flop.Schema do
   - `:string`
   - `:integer`
   - `Ecto.UUID`
-  - `{:parameterized, Ecto.Enum, Ecto.Enum.init(values: [:one, :two])}`
+  - `{:parameterized, {Ecto.Enum, Ecto.Enum.init(values: [:one, :two])}}`
 
   Or reference a schema field:
 

--- a/test/flop/filter_test.exs
+++ b/test/flop/filter_test.exs
@@ -16,7 +16,7 @@ defmodule Flop.FilterTest do
   end
 
   describe "allowed_operators/1" do
-    test "returns a list of operators for each native Ecto type" do
+    test "returns a list of operators for each Ecto type" do
       types = [
         :id,
         :binary_id,
@@ -36,12 +36,19 @@ defmodule Flop.FilterTest do
         :naive_datetime_usec,
         :utc_datetime,
         :utc_datetime_usec,
-        {:parameterized, {Ecto.Enum, %{type: :string}}}
+        {:parameterized, {Ecto.Enum, %{type: :string}}},
+        {:ecto_enum, [:one, :two]},
+        {:from_schema, MyApp.Pet, :mood}
       ]
 
       for type <- types do
-        assert [op | _] = Filter.allowed_operators(type)
+        assert [op | _] = ops_for_type = Filter.allowed_operators(type)
         assert is_atom(op)
+
+        ops_for_field =
+          Filter.allowed_operators(%Flop.FieldInfo{ecto_type: type})
+
+        assert ops_for_type == ops_for_field
       end
     end
 

--- a/test/flop/filter_test.exs
+++ b/test/flop/filter_test.exs
@@ -36,7 +36,7 @@ defmodule Flop.FilterTest do
         :naive_datetime_usec,
         :utc_datetime,
         :utc_datetime_usec,
-        {:parameterized, Ecto.Enum, type: :string}
+        {:parameterized, {Ecto.Enum, %{type: :string}}}
       ]
 
       for type <- types do

--- a/test/flop/filter_test.exs
+++ b/test/flop/filter_test.exs
@@ -52,6 +52,41 @@ defmodule Flop.FilterTest do
       end
     end
 
+    test "returns list of operators for enum" do
+      types = [
+        # by internal representation Ecto < 3.12.0
+        {:parameterized, Ecto.Enum, %{type: :string}},
+        # by internal representation Ecto >= 3.12.0
+        {:parameterized, {Ecto.Enum, %{type: :string}}},
+        # same with init function
+        Ecto.ParameterizedType.init(Ecto.Enum, values: [:one, :two]),
+        # by convenience format
+        {:ecto_enum, [:one, :two]},
+        # by reference
+        {:from_schema, MyApp.Pet, :mood}
+      ]
+
+      expected_ops = [
+        :==,
+        :!=,
+        :empty,
+        :not_empty,
+        :<=,
+        :<,
+        :>=,
+        :>,
+        :in,
+        :not_in
+      ]
+
+      for type <- types do
+        assert Filter.allowed_operators(type) == expected_ops
+
+        assert Filter.allowed_operators(%Flop.FieldInfo{ecto_type: type}) ==
+                 expected_ops
+      end
+    end
+
     test "returns a list of operators for unknown types" do
       assert [op | _] = Filter.allowed_operators(:unicorn)
       assert is_atom(op)

--- a/test/flop/validation_test.exs
+++ b/test/flop/validation_test.exs
@@ -1050,5 +1050,23 @@ defmodule Flop.ValidationTest do
       assert {:error, changeset} = validate(params, for: Owner)
       assert [%{value: ["is invalid"]}] = errors_on(changeset)[:filters]
     end
+
+    test "casts filter values as ecto enums when using parameterized type" do
+      field = :pet_mood_as_parameterized_type
+
+      params = %{filters: [%{field: field, op: :==, value: "happy"}]}
+      assert %{filters: [%{value: :happy}]} = validate!(params, for: Owner)
+
+      params = %{filters: [%{field: field, op: :==, value: :happy}]}
+      assert %{filters: [%{value: :happy}]} = validate!(params, for: Owner)
+
+      params = %{filters: [%{field: field, op: :==, value: "joyful"}]}
+      assert {:error, changeset} = validate(params, for: Owner)
+      assert [%{value: ["is invalid"]}] = errors_on(changeset)[:filters]
+
+      params = %{filters: [%{field: field, op: :==, value: :joyful}]}
+      assert {:error, changeset} = validate(params, for: Owner)
+      assert [%{value: ["is invalid"]}] = errors_on(changeset)[:filters]
+    end
   end
 end

--- a/test/support/owner.ex
+++ b/test/support/owner.ex
@@ -8,7 +8,12 @@ defmodule MyApp.Owner do
 
   @derive {
     Flop.Schema,
-    filterable: [:name, :pet_mood_as_reference, :pet_mood_as_enum],
+    filterable: [
+      :name,
+      :pet_mood_as_reference,
+      :pet_mood_as_enum,
+      :pet_mood_as_parameterized_type
+    ],
     sortable: [:name, :age],
     join_fields: [
       pet_age: [
@@ -24,6 +29,12 @@ defmodule MyApp.Owner do
         binding: :pets,
         field: :mood,
         ecto_type: {:ecto_enum, [:happy, :playful]}
+      ],
+      pet_mood_as_parameterized_type: [
+        binding: :pets,
+        field: :mood,
+        ecto_type:
+          Ecto.ParameterizedType.init(Ecto.Enum, values: [:happy, :playful])
       ]
     ],
     compound_fields: [age_and_pet_age: [:age, :pet_age]],


### PR DESCRIPTION
I was wrong, fields defined as `{:parameterized, Ecto.Enum, Ecto.Enum.init(values: ...)}` are passed as-is and thus don't work with new Ecto. I added a missing test to cover this case.

Flop needs to either manually translate them to preserve backwards compatibility or add this to upgrading guide 😢 This PR assumes the latter, but don't feel pushed to proceed with this.