### PR TITLE
feat: add :or operator for compound field filter with = instead of like

### DIFF
--- a/lib/flop/adapter/ecto.ex
+++ b/lib/flop/adapter/ecto.ex
@@ -34,7 +34,8 @@ defmodule Flop.Adapter.Ecto do
     :like_and,
     :like_or,
     :ilike_and,
-    :ilike_or
+    :ilike_or,
+    :or
   ]
 
   @backend_options [
@@ -158,7 +159,8 @@ defmodule Flop.Adapter.Ecto do
            :ilike_and,
            :ilike_or,
            :empty,
-           :not_empty
+           :not_empty,
+           :or
          ],
          extra: %{fields: fields, type: :compound}
        }}
@@ -501,13 +503,14 @@ defmodule Flop.Adapter.Ecto do
 
   ## Filter query builder
 
-  for op <- [:like_and, :like_or, :ilike_and, :ilike_or] do
+  for op <- [:like_and, :like_or, :ilike_and, :ilike_or, :or] do
     {field_op, combinator} =
       case op do
         :ilike_and -> {:ilike, :and}
         :ilike_or -> {:ilike, :or}
         :like_and -> {:like, :and}
         :like_or -> {:like, :or}
+        :or -> {:==, :or}
       end
 
     defp build_op(

--- a/lib/flop/adapter/ecto/operators.ex
+++ b/lib/flop/adapter/ecto/operators.ex
@@ -274,6 +274,18 @@ defmodule Flop.Adapter.Ecto.Operators do
     {fragment, prelude, combinator}
   end
 
+  def op_config(:or) do
+    fragment =
+      quote do
+        field(r, ^var!(field)) == ^var!(value)
+      end
+
+    combinator = :or
+    prelude = prelude(:maybe_split_search_text)
+
+    {fragment, prelude, combinator}
+  end
+
   defp empty do
     quote do
       is_nil(field(r, ^var!(field))) == ^var!(value)

--- a/lib/flop/filter.ex
+++ b/lib/flop/filter.ex
@@ -96,6 +96,7 @@ defmodule Flop.Filter do
           | :not_ilike
           | :ilike_and
           | :ilike_or
+          | :or
 
   @operators [
     :==,
@@ -118,7 +119,8 @@ defmodule Flop.Filter do
     :ilike,
     :not_ilike,
     :ilike_and,
-    :ilike_or
+    :ilike_or,
+    :or
   ]
 
   @primary_key false

--- a/lib/flop/schema.ex
+++ b/lib/flop/schema.ex
@@ -108,7 +108,7 @@ defprotocol Flop.Schema do
 
   Setting the value to `nil` (default) allows all pagination types.
 
-  See also `t:Flop.option/0`. 
+  See also `t:Flop.option/0`.
 
   ## Alias fields
 
@@ -199,18 +199,18 @@ defprotocol Flop.Schema do
 
   ### Filter operator rules
 
-  - `:=~` `:like` `:not_like` `:like_and` `:like_or` `:ilike` `:not_ilike` `:ilike_and` `:ilike_or`  
+  - `:=~` `:like` `:not_like` `:like_and` `:like_or` `:ilike` `:not_ilike` `:ilike_and` `:ilike_or`
     If a string value is passed it will be split at whitespace
     characters and each segment will be checked separately. If a list of strings is
     passed the individual strings are not split. The filter matches for a value
     if it matches for any of the fields.
-  - `:empty`  
+  - `:empty`
     Matches if all fields of the compound field are `nil`.
-  - `:not_empty`  
+  - `:not_empty`
     Matches if any field of the compound field is not `nil`.
-  - `:==` `:!=` `:<=` `:<` `:>=` `:>` `:in` `:not_in` `:contains` `:not_contains`  
+  - `:==` `:!=` `:<=` `:<` `:>=` `:>` `:in` `:not_in` `:contains` `:not_contains`
     ** These filter operators are ignored for compound fields at the moment.
-    This will be added in a future version.**  
+    This will be added in a future version.**
     The filter value is normalized by splitting the string at whitespaces and
     joining it with a space. The values of all fields of the compound field are
     split by whitespace character and joined with a space, and the resulting
@@ -655,7 +655,8 @@ defprotocol Flop.Schema do
           :ilike_and,
           :ilike_or,
           :empty,
-          :not_empty
+          :not_empty,
+          :or
         ],
         extra: %{type: :compound, fields: [:family_name, :given_name]}
       }

--- a/test/base/flop/filter_test.exs
+++ b/test/base/flop/filter_test.exs
@@ -177,7 +177,8 @@ defmodule Flop.FilterTest do
                :ilike_and,
                :ilike_or,
                :empty,
-               :not_empty
+               :not_empty,
+               :or
              ]
     end
   end


### PR DESCRIPTION
ref: https://github.com/woylie/flop/issues/517

adding :or operator for compound field filter with `=` instead of `like`

e.g.
```
compound_fields: [
  new_uuid: [
    :uuid1,
    :uuid2,
  ]
],
```

this way we can filter new_uuid with `or` operator
which will generate 
`uuid1 = $1 OR uuid2 = $2` 

this is needed because uuid field type will fail when using `like` operator
e.g. `select * from my_table where id like '<uuid value>';`