### PR TITLE
Add sorting by custom fields

### DIFF
--- a/lib/flop.ex
+++ b/lib/flop.ex
@@ -1348,7 +1348,7 @@ defmodule Flop do
       iex> msg
       "has an invalid entry"
       iex> enum
-      [:name, :age, :owner_name, :owner_age]
+      [:name, :age, :owner_name, :owner_age, :dog_age]
 
   Note that currently, trying to use an existing field that is not allowed as
   seen above will result in the error message `has an invalid entry`, while

--- a/lib/flop/nimble_schemas.ex
+++ b/lib/flop/nimble_schemas.ex
@@ -102,7 +102,11 @@ defmodule Flop.NimbleSchemas do
           keys: [
             filter: [
               type: {:tuple, [:atom, :atom, :keyword_list]},
-              required: true
+              required: false
+            ],
+            sorter: [
+              type: {:tuple, [:atom, :atom, :keyword_list]},
+              required: false
             ],
             ecto_type: [type: :any],
             bindings: [type: {:list, :atom}],

--- a/lib/flop/schema.ex
+++ b/lib/flop/schema.ex
@@ -675,6 +675,7 @@ defprotocol Flop.Schema do
         extra: %{
           type: :custom,
           filter: {MyApp.Pet, :reverse_name_filter, []},
+          sorter: nil,
           bindings: []
         }
       }

--- a/test/adapters/ecto/cases/flop_test.exs
+++ b/test/adapters/ecto/cases/flop_test.exs
@@ -97,6 +97,14 @@ defmodule Flop.Adapters.Ecto.FlopTest do
       assert result == expected
     end
 
+    test "orders by custom fields" do
+      pets = insert_list(5, :pet)
+      expected = Enum.sort_by(pets, &Kernel.*(&1.age, 7), :asc)
+      result = Flop.all(Pet, %Flop{order_by: [:dog_age]}, for: Pet)
+
+      assert result == expected
+    end
+
     test "orders by compound fields" do
       pets = insert_list(20, :pet)
 

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -151,6 +151,12 @@ defmodule Flop.Generators do
   def cursor_fields(%{} = schema) do
     schema
     |> Flop.Schema.sortable()
+    |> Enum.reject(fn field ->
+      %Flop.FieldInfo{extra: %{type: field_type}} =
+        Flop.Schema.field_info(schema, field)
+
+      field_type in [:alias, :compound, :custom]
+    end)
     |> Enum.shuffle()
     |> constant()
   end

--- a/test/support/pet.ex
+++ b/test/support/pet.ex
@@ -23,7 +23,7 @@ defmodule MyApp.Pet do
       :custom,
       :reverse_name
     ],
-    sortable: [:name, :age, :owner_name, :owner_age],
+    sortable: [:name, :age, :owner_name, :owner_age, :dog_age],
     max_limit: 1000,
     adapter_opts: [
       compound_fields: [
@@ -55,6 +55,9 @@ defmodule MyApp.Pet do
         reverse_name: [
           filter: {__MODULE__, :reverse_name_filter, []},
           ecto_type: :string
+        ],
+        dog_age: [
+          sorter: {__MODULE__, :dog_age_sorter, []}
         ]
       ]
     ]
@@ -86,6 +89,10 @@ defmodule MyApp.Pet do
   def reverse_name_filter(query, %Flop.Filter{value: value}, _) do
     reversed = value
     where(query, [p], p.name == ^reversed)
+  end
+
+  def dog_age_sorter(query, direction, _opts) do
+    order_by(query, [p], [{^direction, fragment("? * 7", p.age)}])
   end
 
   def get_field(%__MODULE__{owner: %Owner{age: age}}, :owner_age), do: age


### PR DESCRIPTION
Initial implementation of custom field sorting as describe in [511](https://github.com/woylie/flop/issues/511). This allows users to define fields they want to do arbitrary sorting without having to alias a field.

Another bonus is you can technically pass in variables to do some pretty fun dynamic sorting. Right now I'm using them to surface relavent information to a user (PostGIS coordinate compared to user location).

For now we handle those custom variables in our code and pass them in. In the future it would be cool to see that a bit more formalized since we have to basically repeat some boilerplate for verifying some of these custom sort variables.

One additional sticky situation I found while doing this implementation is cursor fields, given other complex fields are not supported I opted to do the same here. However in theory it wouldn't be much work to support, it really just requires that a `get_field/1` callback can execute at runtime (a bit weird though if you rely on runtime options like I'm doing above), then we would just need to validate that a filter function is set in addition to the sorter function for the custom field.