### PR TITLE
Support operators in and not_in with ecto_type {:array, type}

### DIFF
--- a/lib/flop/filter.ex
+++ b/lib/flop/filter.ex
@@ -184,10 +184,12 @@ defmodule Flop.Filter do
   defp value_type(_, :like_or), do: Like
   defp value_type(nil, _), do: Any
   defp value_type(%FieldInfo{ecto_type: type}, op), do: value_type(type, op)
-  defp value_type(type, :in), do: {:array, type}
-  defp value_type(type, :not_in), do: {:array, type}
+  defp value_type({:array, type}, :in), do: type
+  defp value_type({:array, type}, :not_in), do: type
   defp value_type({:array, type}, :contains), do: type
   defp value_type({:array, type}, :not_contains), do: type
+  defp value_type(type, :in), do: {:array, type}
+  defp value_type(type, :not_in), do: {:array, type}
   defp value_type(type, _), do: type
 
   defp expand_type({:from_schema, module, field}) do

--- a/test/base/flop/validation_test.exs
+++ b/test/base/flop/validation_test.exs
@@ -888,6 +888,9 @@ defmodule Flop.ValidationTest do
         params = %{filters: [%{field: :age, value: ["five"]}]}
         assert {:error, changeset} = validate(params, for: Pet)
         assert [%{value: ["is invalid"]}] = errors_on(changeset)[:filters]
+
+        params = %{filters: [%{field: :owner_tags, op: op, value: "a"}]}
+        assert {:ok, %{filters: [%{value: "a"}]}} = validate(params, for: Pet)
       end
     end
 


### PR DESCRIPTION
Fixes #569 