### PR TITLE
fix: deduplicate fields to prevent Elixir 1.20 redundant clause warnings

### DIFF
--- a/lib/flop/adapter/ecto.ex
+++ b/lib/flop/adapter/ecto.ex
@@ -137,11 +137,14 @@ defmodule Flop.Adapter.Ecto do
 
   @impl Flop.Adapter
   def fields(struct, opts) do
-    alias_fields(opts) ++
-      compound_fields(opts) ++
-      custom_fields(opts) ++
-      join_fields(opts) ++
-      schema_fields(struct)
+    Enum.uniq_by(
+      alias_fields(opts) ++
+        compound_fields(opts) ++
+        custom_fields(opts) ++
+        join_fields(opts) ++
+        schema_fields(struct),
+      fn {name, _} -> name end
+    )
   end
 
   defp alias_fields(%{alias_fields: alias_fields}) do


### PR DESCRIPTION
When a join or alias field shares a name with a schema field, `fields/2` returns duplicate entries, causing redundant clause warnings in the generated `field_info/2` and `get_field/2` functions on Elixir 1.20.