### PR TITLE
fix(flop-validation): reset conflicting pagination fields if replace_invalid_params is true

### DIFF
--- a/lib/flop/validation.ex
+++ b/lib/flop/validation.ex
@@ -92,10 +92,16 @@ defmodule Flop.Validation do
   @spec validate_exclusive(Changeset.t(), [[atom]], keyword) :: Changeset.t()
   defp validate_exclusive(changeset, field_groups, opts) do
     changes = changeset.changes
+    errors = changeset.errors
 
     changed_field_groups =
       Enum.filter(field_groups, fn fields ->
-        Enum.any?(fields, &Map.has_key?(changes, &1))
+        Enum.any?(
+          fields,
+          fn field ->
+            Map.has_key?(changes, field) || Keyword.has_key?(errors, field)
+          end
+        )
       end)
 
     if length(changed_field_groups) > 1 do
@@ -104,7 +110,14 @@ defmodule Flop.Validation do
       if opts[:replace_invalid_params] do
         field_groups
         |> List.flatten()
-        |> Enum.reduce(changeset, &Changeset.delete_change(&2, &1))
+        |> Enum.reduce(
+          changeset,
+          fn field, acc ->
+            acc
+            |> Changeset.delete_change(field)
+            |> Map.update!(:errors, &Keyword.delete(&1, field))
+          end
+        )
       else
         Changeset.add_error(
           changeset,

--- a/lib/flop/validation.ex
+++ b/lib/flop/validation.ex
@@ -110,14 +110,7 @@ defmodule Flop.Validation do
       if opts[:replace_invalid_params] do
         field_groups
         |> List.flatten()
-        |> Enum.reduce(
-          changeset,
-          fn field, acc ->
-            acc
-            |> Changeset.delete_change(field)
-            |> Map.update!(:errors, &Keyword.delete(&1, field))
-          end
-        )
+        |> Enum.reduce(changeset, &delete_change_and_errors(&2, &1))
       else
         Changeset.add_error(
           changeset,
@@ -128,6 +121,12 @@ defmodule Flop.Validation do
     else
       changeset
     end
+  end
+
+  defp delete_change_and_errors(changeset, field) do
+    changeset
+    |> Changeset.delete_change(field)
+    |> Map.update!(:errors, &Keyword.delete(&1, field))
   end
 
   defp validate_pagination(changeset, opts) do

--- a/test/base/flop/validation_test.exs
+++ b/test/base/flop/validation_test.exs
@@ -655,6 +655,30 @@ defmodule Flop.ValidationTest do
     end
   end
 
+  describe "mixing pagination types" do
+    test "clears all conflicting fields regardless of data when replace_invalid_params is true" do
+      cases = [
+        %{offset: 10, page: "invalid"},
+        %{offset: 10, page: 10},
+        %{first: 10, last: 10, page: 10}
+      ]
+
+      Enum.each(cases, fn params ->
+        assert {:ok, %Flop{} = flop} =
+                 validate(params, replace_invalid_params: true)
+
+        # all conflicting pagination fields reset
+        assert flop.offset == nil
+        assert flop.page == nil
+        assert flop.first == nil
+        assert flop.last == nil
+
+        # default limit
+        assert flop.limit == 50
+      end)
+    end
+  end
+
   describe "order parameters" do
     test "applies default order" do
       # struct without configured default order


### PR DESCRIPTION
There is an issue where if conflicting pagination types are set, and if at least one of them is malformed (e.g. not an integer), the `Flop.validate` function returns an `{error, changeset}` tuple even if `replace_invalid_params` is set to true.

This is an attempt to fix by ensuring that all conflicting pagination fields are reset if there is a conflict and `replace_invalid_params` is set to true. 