### PR TITLE
fix: don't raise ArgumentError when filters map has non-integer keys

### DIFF
--- a/lib/flop/meta.ex
+++ b/lib/flop/meta.ex
@@ -178,7 +178,12 @@ defmodule Flop.Meta do
   defp filters_to_list(%{"filters" => filters} = params) when is_map(filters) do
     filters =
       filters
-      |> Enum.map(fn {index, filter} -> {String.to_integer(index), filter} end)
+      |> Enum.flat_map(fn {index, filter} ->
+        case parse_filter_index(index) do
+          {:ok, n} -> [{n, filter}]
+          :error -> []
+        end
+      end)
       |> Enum.sort_by(fn {index, _} -> index end)
       |> Enum.map(fn {_, filter} -> filter end)
 
@@ -186,6 +191,17 @@ defmodule Flop.Meta do
   end
 
   defp filters_to_list(params), do: params
+
+  defp parse_filter_index(index) when is_integer(index), do: {:ok, index}
+
+  defp parse_filter_index(index) when is_binary(index) do
+    case Integer.parse(index) do
+      {n, ""} -> {:ok, n}
+      _ -> :error
+    end
+  end
+
+  defp parse_filter_index(_), do: :error
 
   defp map_to_string_keys(value) when is_struct(value), do: value
 

--- a/lib/flop/meta.ex
+++ b/lib/flop/meta.ex
@@ -176,21 +176,28 @@ defmodule Flop.Meta do
   end
 
   defp filters_to_list(%{"filters" => filters} = params) when is_map(filters) do
-    filters =
-      filters
-      |> Enum.flat_map(fn {index, filter} ->
-        case parse_filter_index(index) do
-          {:ok, n} -> [{n, filter}]
-          :error -> []
-        end
-      end)
-      |> Enum.sort_by(fn {index, _} -> index end)
-      |> Enum.map(fn {_, filter} -> filter end)
-
-    Map.put(params, "filters", filters)
+    case parse_filter_map(filters) do
+      :error -> params
+      pairs -> Map.put(params, "filters", sort_filter_pairs(pairs))
+    end
   end
 
   defp filters_to_list(params), do: params
+
+  defp parse_filter_map(filters) do
+    Enum.reduce_while(filters, [], fn {index, filter}, acc ->
+      case parse_filter_index(index) do
+        {:ok, n} -> {:cont, [{n, filter} | acc]}
+        :error -> {:halt, :error}
+      end
+    end)
+  end
+
+  defp sort_filter_pairs(pairs) do
+    pairs
+    |> Enum.sort_by(fn {n, _} -> n end)
+    |> Enum.map(fn {_, filter} -> filter end)
+  end
 
   defp parse_filter_index(index) when is_integer(index), do: {:ok, index}
 

--- a/test/base/flop/meta_test.exs
+++ b/test/base/flop/meta_test.exs
@@ -20,7 +20,9 @@ defmodule Flop.MetaTest do
              ]
     end
 
-    test "drops entries with non-integer string keys" do
+    test "preserves the original map when any key is non-integer" do
+      # Round-trips the malformed shape into meta.params so the caller can
+      # see exactly what they sent, instead of partially normalising it.
       params = %{
         "filters" => %{
           "0" => %{"field" => "name", "value" => "a"},
@@ -30,7 +32,10 @@ defmodule Flop.MetaTest do
 
       meta = Flop.Meta.with_errors(params, [], [])
 
-      assert meta.params["filters"] == [%{"field" => "name", "value" => "a"}]
+      assert meta.params["filters"] == %{
+               "0" => %{"field" => "name", "value" => "a"},
+               "bogus_xyz" => "x"
+             }
     end
 
     test "does not raise on a filter map keyed entirely by field names" do
@@ -38,7 +43,7 @@ defmodule Flop.MetaTest do
 
       meta = Flop.Meta.with_errors(params, [], [])
 
-      assert meta.params["filters"] == []
+      assert meta.params["filters"] == %{"transport_type_code" => "SEA"}
     end
 
     test "leaves list-form filters untouched" do
@@ -58,7 +63,8 @@ defmodule Flop.MetaTest do
       assert {:error, %Flop.Meta{} = meta} =
                Flop.validate(%{"filters" => %{"transport_type_code" => "SEA"}})
 
-      assert is_list(meta.params["filters"])
+      # Original shape preserved so callers can see what they sent.
+      assert meta.params["filters"] == %{"transport_type_code" => "SEA"}
     end
   end
 end

--- a/test/base/flop/meta_test.exs
+++ b/test/base/flop/meta_test.exs
@@ -2,4 +2,63 @@ defmodule Flop.MetaTest do
   use ExUnit.Case, async: true
 
   doctest Flop.Meta, import: true
+
+  describe "with_errors/3" do
+    test "sorts filters by numeric index, not lexicographic" do
+      params = %{
+        "filters" => %{
+          "10" => %{"field" => "name", "value" => "z"},
+          "2" => %{"field" => "name", "value" => "a"}
+        }
+      }
+
+      meta = Flop.Meta.with_errors(params, [], [])
+
+      assert meta.params["filters"] == [
+               %{"field" => "name", "value" => "a"},
+               %{"field" => "name", "value" => "z"}
+             ]
+    end
+
+    test "drops entries with non-integer string keys" do
+      params = %{
+        "filters" => %{
+          "0" => %{"field" => "name", "value" => "a"},
+          "bogus_xyz" => "x"
+        }
+      }
+
+      meta = Flop.Meta.with_errors(params, [], [])
+
+      assert meta.params["filters"] == [%{"field" => "name", "value" => "a"}]
+    end
+
+    test "does not raise on a filter map keyed entirely by field names" do
+      params = %{"filters" => %{"transport_type_code" => "SEA"}}
+
+      meta = Flop.Meta.with_errors(params, [], [])
+
+      assert meta.params["filters"] == []
+    end
+
+    test "leaves list-form filters untouched" do
+      params = %{"filters" => [%{"field" => "name", "value" => "a"}]}
+
+      meta = Flop.Meta.with_errors(params, [], [])
+
+      assert meta.params["filters"] == [%{"field" => "name", "value" => "a"}]
+    end
+  end
+
+  describe "Flop.validate/2" do
+    test "does not raise when filters is a map keyed by field names" do
+      # Regression: previously raised ArgumentError in
+      # Flop.Meta.filters_to_list/1 via with_errors/3, before validate/2
+      # could return its usual {:error, %Flop.Meta{}} tuple.
+      assert {:error, %Flop.Meta{} = meta} =
+               Flop.validate(%{"filters" => %{"transport_type_code" => "SEA"}})
+
+      assert is_list(meta.params["filters"])
+    end
+  end
 end


### PR DESCRIPTION
## Summary
`Flop.Meta.filters_to_list/1` calls `String.to_integer/1` directly on every key of the `filters` map, raising `ArgumentError` on any non-integer key. This causes Flop to crash with an uncaught exception before it can return its documented `{:error, %Flop.Meta{}}` validation tuple.

The crash also affects Flop's own error-construction path: `Flop.Meta.with_errors/3` calls `filters_to_list/1` when building the `params` field of an error meta, so once a malformed map reaches Flop, *even constructing the error tuple* re-raises. That makes it impossible for callers to recover via the public `Flop.validate/2` / `Flop.validate_and_run/3` contract.

## Repro

```elixir
iex(1)> Flop.validate(%{"filters" => %{"name" => "foo"}})
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not a textual representation of an integer

    (erts 16.2) :erlang.binary_to_integer("name")
    (flop 0.26.3) lib/flop/meta.ex:181: anonymous fn/1 in Flop.Meta.filters_to_list/1
    (elixir 1.19.5) lib/enum.ex:1696: anonymous fn/3 in Enum.map/2
    (stdlib 7.2) maps.erl:894: :maps.fold_1/4
    (elixir 1.19.5) lib/enum.ex:2532: Enum.map/2
    (flop 0.26.3) lib/flop/meta.ex:181: Flop.Meta.filters_to_list/1
    (flop 0.26.3) lib/flop/meta.ex:167: Flop.Meta.with_errors/3
    (flop 0.26.3) lib/flop.ex:1382: Flop.validate/2
    iex:1: (file)
iex(1)> 
```

Observed in production from a misconfigured client sending `?filters[transport_type_code]=SEA`. The map-keyed-by-field name form is invalid input, but it should surface as a validation error rather than an uncaught exception.

## Change

Replace `String.to_integer/1` with a `parse_filter_index/1` helper that accepts integer keys as-is and uses `Integer.parse/1` for string keys, requiring the entire string to parse. Entries with non-integer keys are dropped silently from the resulting list - matching how the fallthrough clause already treats filters values that aren't in the indexed-map shape. Behaviour for all currently-valid inputs is unchanged.

## Tests

Added in `test/base/flop/meta_test.exs`:
- Regression: filters are sorted by numeric index, not lexicographic
- New: non-integer keys are dropped, mixed maps keep only valid entries
- New: field-name-keyed map no longer raises
- Regression: list-form filters pass through untouched
- Round-trip: `Flop.validate/2` returns `{:error, %Flop.Meta{}}` for a field-name-keyed filter map
