### PR TITLE
Fix Elixir 1.20 compatibility

### DIFF
--- a/lib/flop/schema.ex
+++ b/lib/flop/schema.ex
@@ -1039,7 +1039,7 @@ defimpl Flop.Schema, for: Any do
 
   def build_get_field_func(struct, adapter, adapter_opts) do
     for {field, field_info} <- adapter.fields(struct, adapter_opts) do
-      quote do
+      quote generated: true do
         def get_field(struct, unquote(field)) do
           unquote(adapter).get_field(
             struct,


### PR DESCRIPTION
Hi there! Thank you for Flop. My teams have used it happily on every Phoenix project I've worked on over the last 5 yeras. ☺️ 

This fixes warnings in client code (not just when compiling the Flop library itself) under Elixir 1.20-rc.5, which made it impossible to compile the client app with `--warnings-as-errors`.

The warnings looked like this:

```
    warning: the following clause is redundant:

        def get_field(struct, :user_name)

    it has type:

        dynamic(%MyApp.Topic{}), :user_name

    previous clauses have already matched on the following types:

        %MyApp.Topic{}, :name
        %MyApp.Topic{}, :user_name
        %MyApp.Topic{}, :account_name

    │
 82 │   embedded_schema do
    │   ~~~~~~~~~~~~~~~~~~
    │
    └─ lib/my_app/topic.ex:82: Flop.Schema.MyApp.Topic.get_field/2
```

This PR applies [the fix suggested by José](https://github.com/elixir-lang/elixir/issues/15395) for macros generating dead code.